### PR TITLE
Taked alpine:latest to use with printout what version of alpine in use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13.0
+FROM alpine:latest
 
 ARG USER=notroot
 ARG GROUP=notroot
@@ -6,6 +6,8 @@ ARG UID=1000
 ARG GID=1000
 
 RUN set -xe && \
+    echo $(echo BUILD_TIME_ALPINE_VERSION: && /bin/cat /etc/alpine-release) && \
+    apk upgrade --no-cache && \
     apk add --no-cache \
         git \
         python3 \
@@ -28,7 +30,6 @@ RUN set -xe && \
         libffi-dev \
         libressl-dev && \
     rm -rf /tmp/azure-local-blob-copy && \
-    apk upgrade --no-cache && \
     addgroup -g ${GID} -S ${GROUP} && \
     adduser -u ${UID} -S -D ${USER} ${GROUP}
 
@@ -37,4 +38,4 @@ WORKDIR /home/${USER}
 USER ${USER}
 RUN chmod +x /azure-copy-tool.py
 
-ENTRYPOINT /usr/bin/python3 /azure-copy-tool.py
+ENTRYPOINT echo $(echo ALPINE_VERSION: && /bin/cat /etc/alpine-release) && /usr/bin/python3 /azure-copy-tool.py


### PR DESCRIPTION
Compile time info:
```
 ---> Running in 9b3d3dbdacc7
+ echo BUILD_TIME_ALPINE_VERSION:
+ /bin/cat /etc/alpine-release
BUILD_TIME_ALPINE_VERSION: 3.13.0
+ echo BUILD_TIME_ALPINE_VERSION: 3.13.0
+ apk upgrade --no-cache
fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/main/x86_64/APKINDEX.tar.gz
```

Runtime info:
```
shoisko@DuuniWin10:~/repos/github/Aurora/azure-local-blob-copy$ docker run test2
ALPINE_VERSION: 3.13.0
The environment variable AZURE_STORAGE_CONNECTION_STRING is missing.
shoisko@DuuniWin10:~/repos/github/Aurora/azure-local-blob-copy$
```